### PR TITLE
Fixed bug where pg_hba was being set to enum

### DIFF
--- a/recipes/postgresql.rb
+++ b/recipes/postgresql.rb
@@ -18,10 +18,16 @@ include_recipe "database::postgresql"
 # Replace the line `local all all ident`
 #             with `local all all md5`
 node.set['postgresql']['pg_hba'].map! do |line|
-  if line[:type] == 'local' && line[:db] == 'all' && line[:user] == 'all' && line[:addr] == nil && line[:method] == 'ident' then
-    line[:method] = 'md5'
-  end
-  line
+  if line[:type] == 'local' && line[:db] == 'all' && line[:user] == 'all' && line[:addr] == nil && line[:method] == 'ident'
+    copy = line.to_hash
+    if copy[:method]
+      copy[:method] = 'md5'
+    else
+      copy['method'] = 'md5'
+    end
+    copy
+  else
+    line
 end
 
 postgresql_connection_info = {


### PR DESCRIPTION
There appeared to be a bug when postgres was generating the pg_hba.conf file

The `map!` function was creating some sort of array with an enum `["map!", {}]` As such, postgres was throwing `no implicit conversion of Symbol into Integer`. This change fixed the setup for me.
